### PR TITLE
Group could have wrong path name

### DIFF
--- a/asgi_ipc.py
+++ b/asgi_ipc.py
@@ -149,6 +149,7 @@ class IPCChannelLayer(BaseChannelLayer):
 
     def _group_path(self, group):
         assert isinstance(group, six.text_type)
+        assert group.find('/') == -1
         return "/%s-group-%s" % (self.prefix, group.encode("ascii"))
 
     def _channel_list(self, channel):


### PR DESCRIPTION
Didn't know that there couldn't be any slashes in the group path, so being extra explicit about it. Don't know if this belongs to this module or is just something I didn't know about Django Channels.
