### PR TITLE
catch key error that is result of non existing groups

### DIFF
--- a/asgi_ipc/store.py
+++ b/asgi_ipc/store.py
@@ -189,11 +189,14 @@ class GroupMemoryStore(BaseMemoryStore):
         Removes all members from the group who have expired, and returns the
         new list of members.
         """
-        with self.mutate_value() as value:
-            value[name] = {
-                item: expiry
-                for item, expiry in value[name].items()
-                if expiry >= time.time()
-            }
+        try:
+            with self.mutate_value() as value:
+                value[name] = {
+                    item: expiry
+                    for item, expiry in value[name].items()
+                    if expiry >= time.time()
+                }
+        except KeyError:
+            return []
         return value[name].keys()
 


### PR DESCRIPTION
We are using `channels` and `asgi_ipc` in our project for sending a live preview of a document to a group of users.
We recently updated all of our dependencies and found that the live preview sending via `asgi_ipc` does not work anymore.

We are basically sending html through the websocket to everyone interested and subscribed to that group. In previous releases it was no problem to send the message to a group without any members, but with the most current version of the code this is not possible anymore and our workers crash in `store.py` when they try to remove members from the non existing group. We are able to reproduce this error on a range of different Linux based systems in different configurations, I was not able to compile a small standalone code version, that reproduces this error, but I will provide with a step by step list on how to reproduce the error using our system, if there is anybody interested in reproducing the error.

This PR tries to fix this problem, but I'm really not sure whether this is the right way to go.

### Steps to reproduce:

1. Clone our [repository](https://github.com/fsr-itse/1327)
2. Create a `Python 3` virtualenv
3. Install all requirements from the files `requirements.txt`, and `requirements-deploy.txt`
4. Create a file `localsettings.py` in the folder `_1327` and add the following:
 
```
CHANNEL_LAYERS = {
	"default": {
		"BACKEND": "asgi_ipc.IPCChannelLayer",
		"ROUTING": "_1327.routing.channel_routing",
		"CONFIG": {
			"prefix": "1327",
		},
	},
}
```
5. run the command `python manage.py createsuperuser` to create a user
6. run `daphne _1327.asgi:channel_layer`
7. start a worker with `python manage.py runworker`
8. open `localhost:8000` and login
9. go to the menu and create a new `InformationPage`
10. Enter some text in the text area and wait for the worker to crash with a `KeyError`

I know these are quite some steps, but I'm really not sure why this is happening and maybe the reason is something else, than my quick and dirty fix.

Please also see the [ticket](https://github.com/fsr-itse/1327/issues/589) in our repository with the error message.

Please let me know if you need more information